### PR TITLE
feat: introduce github actions to generate HTML and PDF automatially

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  env:
+    IN_FILE: opus-iso-binding.md
+    OUT_FILE_NAME: opus-iso-binding
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - run: sudo gem install kramdown
+      - run: kramdown --template build/html-template ${{ IN_FILE }} > ${{ OUT_FILE_NAME }}.html
+      - run: |
+          docker run --security-opt seccomp=unconfined \
+          --rm -v $(pwd):/converted/ arachnysdocker/athenapdf athenapdf --no-cache \
+          ${{ OUT_FILE_NAME }}.html ${{ OUT_FILE_NAME }}.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,23 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - run: sudo gem install kramdown
-      - run: kramdown --template build/html-template ${{ env.IN_FILE }} > ${{ env.OUT_FILE_NAME }}.html
-      - run: |
+      - name: install kramdown
+        run: sudo gem install kramdown
+      - name: Convert Markdown to HTML
+        run: kramdown --template build/html-template ${{ env.IN_FILE }} > ${{ env.OUT_FILE_NAME }}.html
+      - name: Convert HTML to PDF
+        run: |
           docker run --security-opt seccomp=unconfined \
           --rm -v $(pwd):/converted/ arachnysdocker/athenapdf athenapdf --no-cache \
           ${{ env.OUT_FILE_NAME }}.html ${{ env.OUT_FILE_NAME }}.pdf
+      - name: Gather deploy files
+        run: |
+          mkdir -p /tmp/deploy
+          [[ -d images ]] && cp -r images /tmp/deploy/
+          cp ${{ env.OUT_FILE_NAME }}.html /tmp/deploy/
+          cp ${{ env.OUT_FILE_NAME }}.pdf /tmp/deploy/
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/deploy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - master
 jobs:
-  env:
-    IN_FILE: opus-iso-binding.md
-    OUT_FILE_NAME: opus-iso-binding
   build:
     runs-on: ubuntu-latest
+    env:
+      IN_FILE: opus-iso-binding.md
+      OUT_FILE_NAME: opus-iso-binding
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
           ${{ env.OUT_FILE_NAME }}.html ${{ env.OUT_FILE_NAME }}.pdf
       - name: Gather deploy files
         run: |
-          mkdir -p /tmp/deploy
-          [[ -d images ]] && cp -r images /tmp/deploy/
-          cp ${{ env.OUT_FILE_NAME }}.html /tmp/deploy/
-          cp ${{ env.OUT_FILE_NAME }}.pdf /tmp/deploy/
+          mkdir -p deploy
+          [[ -d images ]] && cp -r images ./deploy/
+          cp ${{ env.OUT_FILE_NAME }}.html ./deploy/
+          cp ${{ env.OUT_FILE_NAME }}.pdf ./deploy/
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: /tmp/deploy/
+          publish_dir: ./deploy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           ruby-version: 2.7
       - run: sudo gem install kramdown
-      - run: kramdown --template build/html-template ${{ IN_FILE }} > ${{ OUT_FILE_NAME }}.html
+      - run: kramdown --template build/html-template ${{ env.IN_FILE }} > ${{ env.OUT_FILE_NAME }}.html
       - run: |
           docker run --security-opt seccomp=unconfined \
           --rm -v $(pwd):/converted/ arachnysdocker/athenapdf athenapdf --no-cache \
-          ${{ OUT_FILE_NAME }}.html ${{ OUT_FILE_NAME }}.pdf
+          ${{ env.OUT_FILE_NAME }}.html ${{ env.OUT_FILE_NAME }}.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,12 @@ jobs:
     env:
       IN_FILE: opus-iso-binding.md
       OUT_FILE_NAME: opus-iso-binding
+      RUBY_VERSION: 2.7
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: ${{ env.RUBY_VERSION }}
       - name: install kramdown
         run: sudo gem install kramdown
       - name: Convert Markdown to HTML

--- a/build/gen.sh
+++ b/build/gen.sh
@@ -6,23 +6,14 @@ outfile='opus-iso-binding'
 
 printf "\nConverting Markdown to HTML ...\n"
 
-kramdown --template html-template ../${infile} | \
-  # Change image path to parent, and make empty <th> truly empty
-  sed -e 's/src="images/src="\.\.\/images/g' \
-  -re 's|<th>\xc2\xa0</th>|<th></th>|g' \
-  > ${outfile}.html
+kramdown --template html-template ../${infile} > ${outfile}.html
 
 printf "\nHTML finished.\n\n"
 
 printf "\nConverting HTML to PDF ...\n\n"
 
-## athenapdf can't handle filesystem paths
-cp -r ../images .
-
 docker run --security-opt seccomp=unconfined \
   --rm -v $(pwd):/converted/ arachnysdocker/athenapdf athenapdf --no-cache \
   ${outfile}.html ${outfile}.pdf
-
-rm -rf images
 
 printf "\nPDF finished.\n\n"


### PR DESCRIPTION
# Motivation

Sometimes, it's a bother for developers to install docker to local env.

@VFR-maniac is one of such developer.

https://twitter.com/ChaosSoulLover/status/1240244707197734912

Why don't you use CI? Let's use Github Actions!

Now, you don't need to install docker to local.

# What changes did you make

- Write Github Actions config file to generate HTML and PDF and deploy to `gh-pages` branch
- fix `build/gen.sh`: some hack is now not required!

# When CI will work?

only when you push to `master` branch.

# What is required after you merge this PR?

You need to enable gh-pages.

see [peaceiris/actions-gh-pages: GitHub Actions for GitHub Pages 🚀 Deploy static files and publish your site easily. Static-Site-Generators-friendly. #First Deployment with GITHUB_TOKEN](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token)

# example deployed gh-pages

- https://yumetodo.github.io/opus-dash/opus-iso-binding.html
- https://yumetodo.github.io/opus-dash/opus-iso-binding.pdf

